### PR TITLE
Optional access token field name

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "nerdishbynature/RequestKit" >= 0.1.1
+github "nerdishbynature/RequestKit" "optional_access_token_field_name"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "nerdishbynature/RequestKit" "optional_access_token_field_name"
+github "nerdishbynature/RequestKit" >=0.2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "nerdishbynature/Nocilla" "0.10.0"
-github "nerdishbynature/RequestKit" "e2333bcbdc84e51e3019559eaf521cda2b926c5e"
+github "nerdishbynature/RequestKit" "0.2.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "nerdishbynature/Nocilla" "0.10.0"
-github "nerdishbynature/RequestKit" "0.1.1"
+github "nerdishbynature/RequestKit" "251bbc4355a313444971550f49458c96a7f1db65"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "nerdishbynature/Nocilla" "0.10.0"
-github "nerdishbynature/RequestKit" "251bbc4355a313444971550f49458c96a7f1db65"
+github "nerdishbynature/RequestKit" "e2333bcbdc84e51e3019559eaf521cda2b926c5e"

--- a/TanukiKit.xcodeproj/project.pbxproj
+++ b/TanukiKit.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		233A0B311C0EFE0400072A58 /* Nocilla.framework in Carthage embed */ = {isa = PBXBuildFile; fileRef = 233A0B2E1C0EFDDC00072A58 /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		233A0B321C0EFE0400072A58 /* RequestKit.framework in Carthage embed */ = {isa = PBXBuildFile; fileRef = 233A0B2C1C0EFDD000072A58 /* RequestKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		233A0B341C0EFE2A00072A58 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233A0B331C0EFE2A00072A58 /* ConfigurationTests.swift */; };
+		23FC28DB1C1AD8AB0017CBDA /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FC28DA1C1AD8AB0017CBDA /* Keys.swift */; };
+		23FC28DD1C1AD8FD0017CBDA /* KeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FC28DC1C1AD8FD0017CBDA /* KeysTests.swift */; };
+		23FC28DF1C1AD9680017CBDA /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FC28DE1C1AD9680017CBDA /* TestHelper.swift */; };
+		23FC28E11C1AD9DD0017CBDA /* public_key.json in Resources */ = {isa = PBXBuildFile; fileRef = 23FC28E01C1AD9DD0017CBDA /* public_key.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +66,10 @@
 		233A0B2C1C0EFDD000072A58 /* RequestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RequestKit.framework; path = ../Carthage/Build/iOS/RequestKit.framework; sourceTree = "<group>"; };
 		233A0B2E1C0EFDDC00072A58 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = ../Carthage/Build/iOS/Nocilla.framework; sourceTree = "<group>"; };
 		233A0B331C0EFE2A00072A58 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		23FC28DA1C1AD8AB0017CBDA /* Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
+		23FC28DC1C1AD8FD0017CBDA /* KeysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeysTests.swift; sourceTree = "<group>"; };
+		23FC28DE1C1AD9680017CBDA /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
+		23FC28E01C1AD9DD0017CBDA /* public_key.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = public_key.json; path = Fixtures/public_key.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +118,7 @@
 				233A0B1D1C0EF94400072A58 /* Configuration.swift */,
 				233A0B1E1C0EF94400072A58 /* GitLabKit.swift */,
 				233A0B1F1C0EF94400072A58 /* Repositories.swift */,
+				23FC28DA1C1AD8AB0017CBDA /* Keys.swift */,
 				233A0B201C0EF94400072A58 /* User.swift */,
 				233A0B081C0EF8E900072A58 /* Info.plist */,
 			);
@@ -122,6 +131,8 @@
 				233A0B271C0EFDB500072A58 /* Fixtures */,
 				233A0B141C0EF8E900072A58 /* Info.plist */,
 				233A0B331C0EFE2A00072A58 /* ConfigurationTests.swift */,
+				23FC28DC1C1AD8FD0017CBDA /* KeysTests.swift */,
+				23FC28DE1C1AD9680017CBDA /* TestHelper.swift */,
 				23523FFA1C0F0CE100216E20 /* Frameworks */,
 			);
 			path = TanukiKitTests;
@@ -132,6 +143,7 @@
 			children = (
 				233A0B281C0EFDBC00072A58 /* Repositories.json */,
 				233A0B291C0EFDBC00072A58 /* User.json */,
+				23FC28E01C1AD9DD0017CBDA /* public_key.json */,
 			);
 			name = Fixtures;
 			sourceTree = "<group>";
@@ -244,6 +256,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23FC28E11C1AD9DD0017CBDA /* public_key.json in Resources */,
 				233A0B2B1C0EFDBC00072A58 /* User.json in Resources */,
 				233A0B2A1C0EFDBC00072A58 /* Repositories.json in Resources */,
 			);
@@ -260,6 +273,7 @@
 				233A0B211C0EF94400072A58 /* Configuration.swift in Sources */,
 				233A0B221C0EF94400072A58 /* GitLabKit.swift in Sources */,
 				233A0B231C0EF94400072A58 /* Repositories.swift in Sources */,
+				23FC28DB1C1AD8AB0017CBDA /* Keys.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -267,7 +281,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23FC28DF1C1AD9680017CBDA /* TestHelper.swift in Sources */,
 				233A0B341C0EFE2A00072A58 /* ConfigurationTests.swift in Sources */,
+				23FC28DD1C1AD8FD0017CBDA /* KeysTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TanukiKit/Configuration.swift
+++ b/TanukiKit/Configuration.swift
@@ -14,6 +14,20 @@ public struct TokenConfiguration: Configuration {
     }
 }
 
+public struct PrivateTokenConfiguration: Configuration {
+    public var apiEndpoint: String
+    public var accessToken: String?
+
+    public init(_ token: String? = nil, url: String = gitlabBaseURL) {
+        apiEndpoint = url
+        accessToken = token
+    }
+
+    public var accessTokenFieldName: String {
+        return "private_token"
+    }
+}
+
 public struct OAuthConfiguration: Configuration {
     public var apiEndpoint: String
     public var accessToken: String?

--- a/TanukiKit/GitLabKit.swift
+++ b/TanukiKit/GitLabKit.swift
@@ -2,9 +2,9 @@ import Foundation
 import RequestKit
 
 public struct TanukiKit {
-    public let configuration: TokenConfiguration
+    public let configuration: Configuration
 
-    public init(_ config: TokenConfiguration = TokenConfiguration()) {
+    public init(_ config: Configuration = TokenConfiguration()) {
         configuration = config
     }
 }

--- a/TanukiKit/Keys.swift
+++ b/TanukiKit/Keys.swift
@@ -1,0 +1,64 @@
+import Foundation
+import RequestKit
+
+// MARK: request
+
+public extension TanukiKit {
+    public func postPublicKey(publicKey: String, title: String, completion: (response:Response<String>) -> Void) {
+        let router = PublicKeyRouter.PostPublicKey(publicKey, title, configuration)
+        router.postJSON([String: AnyObject].self) { json, error in
+            if let error = error {
+                completion(response: Response.Failure(error))
+            } else {
+                if let _ = json {
+                    completion(response: Response.Success(publicKey))
+                }
+            }
+        }
+    }
+}
+
+enum PublicKeyRouter: JSONPostRouter {
+    case PostPublicKey(String, String, Configuration)
+
+    var configuration: Configuration {
+        switch self {
+        case .PostPublicKey(_, _, let config): return config
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .PostPublicKey:
+            return .POST
+        }
+    }
+
+    var encoding: HTTPEncoding {
+        switch self {
+        case .PostPublicKey:
+            return .JSON
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .PostPublicKey:
+            return "user/keys"
+        }
+    }
+
+    var params: [String: String] {
+        switch self {
+        case .PostPublicKey(let publicKey, let title, _):
+            return ["title": title, "key": publicKey]
+        }
+    }
+
+    var URLRequest: NSURLRequest? {
+        switch self {
+        case .PostPublicKey(_, _, _):
+            return request()
+        }
+    }
+}

--- a/TanukiKit/Keys.swift
+++ b/TanukiKit/Keys.swift
@@ -6,7 +6,7 @@ import RequestKit
 public extension TanukiKit {
     public func postPublicKey(publicKey: String, title: String, completion: (response:Response<String>) -> Void) {
         let router = PublicKeyRouter.PostPublicKey(publicKey, title, configuration)
-        router.postJSON([String: AnyObject].self) { json, error in
+        router.loadJSON([String: AnyObject].self) { json, error in
             if let error = error {
                 completion(response: Response.Failure(error))
             } else {
@@ -18,7 +18,7 @@ public extension TanukiKit {
     }
 }
 
-enum PublicKeyRouter: JSONPostRouter {
+enum PublicKeyRouter: Router {
     case PostPublicKey(String, String, Configuration)
 
     var configuration: Configuration {
@@ -37,7 +37,7 @@ enum PublicKeyRouter: JSONPostRouter {
     var encoding: HTTPEncoding {
         switch self {
         case .PostPublicKey:
-            return .JSON
+            return .FORM
         }
     }
 

--- a/TanukiKitTests/ConfigurationTests.swift
+++ b/TanukiKitTests/ConfigurationTests.swift
@@ -29,6 +29,13 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(subject.apiEndpoint, enterpriseURL)
     }
 
+    func testEnterprisePrivateTokenConfiguration() {
+        let subject = PrivateTokenConfiguration("12345", url: enterpriseURL)
+        XCTAssertEqual(subject.accessToken!, "12345")
+        XCTAssertEqual(subject.apiEndpoint, enterpriseURL)
+        XCTAssertEqual(subject.accessTokenFieldName, "private_token")
+    }
+
     func testOAuthConfiguration() {
         let subject = OAuthConfiguration(token: "12345", secret: "6789", redirectURI: "https://oauth.example.com/gitlab_oauth")
         XCTAssertEqual(subject.token, "12345")
@@ -73,5 +80,12 @@ class ConfigurationTests: XCTestCase {
         waitForExpectationsWithTimeout(1, handler: { error in
             XCTAssertNil(error, "\(error)")
         })
+    }
+
+    func testURLRequestWithPrivateTokenConfiguration() {
+        let config = PrivateTokenConfiguration("12345_678", url: "https://gitlab.example.com/api/v3")
+        let request = UserRouter.ReadAuthenticatedUser(config).URLRequest
+        let expected = NSURL(string: "https://gitlab.example.com/api/v3/user?private_token=12345_678")!
+        XCTAssertEqual(request?.URL, expected)
     }
 }

--- a/TanukiKitTests/Fixtures/public_key.json
+++ b/TanukiKitTests/Fixtures/public_key.json
@@ -1,0 +1,6 @@
+{
+    "created_at": "2015-01-21T17:44:33.512Z",
+    "key": "ssh-dss AAAAB3NzaC1kc3MAAACBAMLrhYgI3atfrSD6KDas1b/3n6R/HP+bLaHHX6oh+L1vg31mdUqK0Ac/NjZoQunavoyzqdPYhFz9zzOezCrZKjuJDS3NRK9rspvjgM0xYR4d47oNZbdZbwkI4cTv/gcMlquRy0OvpfIvJtjtaJWMwTLtM5VhRusRuUlpH99UUVeXAAAAFQCVyX+92hBEjInEKL0v13c/egDCTQAAAIEAvFdWGq0ccOPbw4f/F8LpZqvWDydAcpXHV3thwb7WkFfppvm4SZte0zds1FJ+Hr8Xzzc5zMHe6J4Nlay/rP4ewmIW7iFKNBEYb/yWa+ceLrs+TfR672TaAgO6o7iSRofEq5YLdwgrwkMmIawa21FrZ2D9SPao/IwvENzk/xcHu7YAAACAQFXQH6HQnxOrw4dqf0NqeKy1tfIPxYYUZhPJfo9O0AmBW2S36pD2l14kS89fvz6Y1g8gN/FwFnRncMzlLY/hX70FSc/3hKBSbH6C6j8hwlgFKfizav21eS358JJz93leOakJZnGb8XlWvz1UJbwCsnR2VEY8Dz90uIk1l/UqHkA= loic@call",
+    "title": "ABC",
+    "id": 4
+}

--- a/TanukiKitTests/KeysTests.swift
+++ b/TanukiKitTests/KeysTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import TanukiKit
+import Nocilla
+
+class PublicKeyTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        LSNocilla.sharedInstance().start()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        LSNocilla.sharedInstance().clearStubs()
+        LSNocilla.sharedInstance().stop()
+    }
+
+    // MARK: URLRequest Tests
+
+    func testPostPublicKeyURLRequest() {
+        let kit = TanukiKit(TokenConfiguration("12345"))
+        let request = PublicKeyRouter.PostPublicKey("test-key", "test title", kit.configuration).URLRequest
+        XCTAssertEqual(request?.URL, NSURL(string: "https://gitlab.com/api/v3/user/keys?access_token=12345")!)
+    }
+
+    // MARK: Actual Request tests
+
+    func testPostPublicKey() {
+        let config = TokenConfiguration("12345")
+        if let json = TestHelper.stringFromFile("public_key") {
+            stubRequest("POST", "https://gitlab.com/api/v3/user/keys?access_token=12345").andReturn(201).withHeaders(["Content-Type": "application/json"]).withBody(json)
+            let expectation = expectationWithDescription("public_key")
+            TanukiKit(config).postPublicKey("test-key", title: "test title") { response in
+                switch response {
+                case .Success(let publicKey):
+                    XCTAssertEqual(publicKey, "test-key")
+                    expectation.fulfill()
+                case .Failure:
+                    XCTAssert(false, "should not get an error")
+                    expectation.fulfill()
+                }
+            }
+            waitForExpectationsWithTimeout(1) { (error) in
+                XCTAssertNil(error, "\(error)")
+            }
+        } else {
+            XCTFail("json shouldn't be nil")
+        }
+    }
+}

--- a/TanukiKitTests/KeysTests.swift
+++ b/TanukiKitTests/KeysTests.swift
@@ -19,15 +19,15 @@ class PublicKeyTests: XCTestCase {
     func testPostPublicKeyURLRequest() {
         let kit = TanukiKit(TokenConfiguration("12345"))
         let request = PublicKeyRouter.PostPublicKey("test-key", "test title", kit.configuration).URLRequest
-        XCTAssertEqual(request?.URL, NSURL(string: "https://gitlab.com/api/v3/user/keys?access_token=12345")!)
+        XCTAssertEqual(request?.URL, NSURL(string: "https://gitlab.com/api/v3/user/keys")!)
     }
 
     // MARK: Actual Request tests
 
     func testPostPublicKey() {
-        let config = TokenConfiguration("12345")
+        let config = PrivateTokenConfiguration("12345")
         if let json = TestHelper.stringFromFile("public_key") {
-            stubRequest("POST", "https://gitlab.com/api/v3/user/keys?access_token=12345").andReturn(201).withHeaders(["Content-Type": "application/json"]).withBody(json)
+            stubRequest("POST", "https://gitlab.com/api/v3/user/keys").withBody("key=test-key&private_token=12345&title=test%20title").andReturn(201).withHeaders(["Content-Type": "application/json"]).withBody(json)
             let expectation = expectationWithDescription("public_key")
             TanukiKit(config).postPublicKey("test-key", title: "test title") { response in
                 switch response {

--- a/TanukiKitTests/TestHelper.swift
+++ b/TanukiKitTests/TestHelper.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+internal class TestHelper {
+    internal class func stringFromFile(name: String) -> String? {
+        let bundle = NSBundle(forClass: self)
+        let path = bundle.pathForResource(name, ofType: "json")
+        if let path = path {
+            let string = try? String(contentsOfFile: path, encoding: NSUTF8StringEncoding)
+            return string
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
- Add `PrivateTokenConfiguration` which is needed because a private token configuration on non-OAuth based GitLab Enterprise authentication needs the field to be named `private_token` instead of `access_token`.
- Add posting SSH keys
